### PR TITLE
Fix e2e cleanup against current Obsidian (fixes #38)

### DIFF
--- a/tests/e2e-setup/cleanup.ts
+++ b/tests/e2e-setup/cleanup.ts
@@ -38,17 +38,21 @@ test("Unregister test vault", async () => {
 	// ("Open another vault" -> "Manage vaults...").
 	// @ts-expect-error app is a global in the Obsidian renderer
 	await window.waitForFunction(() => window.app?.commands != null);
-	await window.evaluate(() => {
+	const executed = await window.evaluate(() => {
 		// @ts-expect-error app is a global in the Obsidian renderer
-		window.app.commands.executeCommandById("app:open-vault");
+		return window.app.commands.executeCommandById("app:open-vault");
 	});
+	expect(executed, "app:open-vault command should exist").toBe(true);
 
 	// Wait for the vault chooser window. Polling app.windows() instead of
 	// waitForEvent("window") avoids the race where the window opens before
-	// the event listener is registered.
+	// the event listener is registered. On failure the assertion message
+	// shows the URLs of all windows that actually exist.
 	await expect
-		.poll(() => app.windows().some((w) => w.url().includes("starter")))
-		.toBe(true);
+		.poll(() => JSON.stringify(app.windows().map((w) => w.url())), {
+			timeout: 30000,
+		})
+		.toContain("starter");
 	window = app.windows().find((w) => w.url().includes("starter"))!;
 
 	// Close the originally opened window

--- a/tests/e2e-setup/cleanup.ts
+++ b/tests/e2e-setup/cleanup.ts
@@ -43,10 +43,13 @@ test("Unregister test vault", async () => {
 		window.app.commands.executeCommandById("app:open-vault");
 	});
 
-	// Wait for the new window to open
-	window = await app.waitForEvent("window", (w) =>
-		w.url().includes("starter")
-	);
+	// Wait for the vault chooser window. Polling app.windows() instead of
+	// waitForEvent("window") avoids the race where the window opens before
+	// the event listener is registered.
+	await expect
+		.poll(() => app.windows().some((w) => w.url().includes("starter")))
+		.toBe(true);
+	window = app.windows().find((w) => w.url().includes("starter"))!;
 
 	// Close the originally opened window
 	{

--- a/tests/e2e-setup/cleanup.ts
+++ b/tests/e2e-setup/cleanup.ts
@@ -36,8 +36,13 @@ test("Unregister test vault", async () => {
 	// Open the vault chooser. The command is executed by its stable id
 	// because its palette name changed across Obsidian versions
 	// ("Open another vault" -> "Manage vaults...").
-	// @ts-expect-error app is a global in the Obsidian renderer
-	await window.waitForFunction(() => window.app?.commands != null);
+	// Wait until the command is registered; the commands registry exists
+	// before individual commands are added during workspace init.
+	await window.waitForFunction(
+		() =>
+			// @ts-expect-error app is a global in the Obsidian renderer
+			window.app?.commands?.findCommand?.("app:open-vault") != null,
+	);
 	const executed = await window.evaluate(() => {
 		// @ts-expect-error app is a global in the Obsidian renderer
 		return window.app.commands.executeCommandById("app:open-vault");

--- a/tests/e2e-setup/cleanup.ts
+++ b/tests/e2e-setup/cleanup.ts
@@ -36,6 +36,8 @@ test("Unregister test vault", async () => {
 	// Open the vault chooser. The command is executed by its stable id
 	// because its palette name changed across Obsidian versions
 	// ("Open another vault" -> "Manage vaults...").
+	// @ts-expect-error app is a global in the Obsidian renderer
+	await window.waitForFunction(() => window.app?.commands != null);
 	await window.evaluate(() => {
 		// @ts-expect-error app is a global in the Obsidian renderer
 		window.app.commands.executeCommandById("app:open-vault");

--- a/tests/e2e-setup/cleanup.ts
+++ b/tests/e2e-setup/cleanup.ts
@@ -33,18 +33,13 @@ test.afterEach(async () => {
 test("Unregister test vault", async () => {
 	let window = await app.firstWindow();
 
-	// Execute the "Open another vault" command
-	{
-		// Open the command palette
-		await window
-			.getByLabel("Open command palette", { exact: true })
-			.click();
-
-		// Input to the command palette
-		const commandPalette = window.locator(":focus");
-		await commandPalette.fill("open another vault");
-		await commandPalette.press("Enter");
-	}
+	// Open the vault chooser. The command is executed by its stable id
+	// because its palette name changed across Obsidian versions
+	// ("Open another vault" -> "Manage vaults...").
+	await window.evaluate(() => {
+		// @ts-expect-error app is a global in the Obsidian renderer
+		window.app.commands.executeCommandById("app:open-vault");
+	});
 
 	// Wait for the new window to open
 	window = await app.waitForEvent("window", (w) =>


### PR DESCRIPTION
Obsidian renamed the app:open-vault command from "Open another vault"
to "Manage vaults...", so the command-palette text search silently
matched nothing and the test timed out waiting for the starter window.
Execute the command by its stable id instead of driving the palette.
