### PR TITLE
Stabilize e2e teardown against the latest Obsidian

### DIFF
--- a/tests/e2e-setup/cleanup.ts
+++ b/tests/e2e-setup/cleanup.ts
@@ -24,10 +24,30 @@ test.beforeEach(async () => {
 			`obsidian://open?path=${encodeURIComponent(vaultPath)}`,
 		],
 	});
+
+	// Handle JS dialogs (e.g. beforeunload on app close) explicitly.
+	// Playwright's implicit auto-dismiss races with Obsidian closing its own
+	// dialogs ("No dialog is showing" protocol error), which hangs teardown.
+	const handleDialogs = (page) => {
+		page.on("dialog", (dialog) => dialog.accept().catch(() => {}));
+	};
+	app.on("window", handleDialogs);
+	for (const page of app.windows()) {
+		handleDialogs(page);
+	}
 });
 
 test.afterEach(async () => {
-	await app?.close();
+	if (!app) return;
+	// app.close() can hang if Obsidian blocks shutdown, so bound it and
+	// force-kill as a fallback. The process handle must be grabbed before
+	// close(): a disposed ElectronApplication throws from process().
+	const obsidianProcess = app.process();
+	await Promise.race([
+		app.close(),
+		new Promise((resolve) => setTimeout(resolve, 15_000)),
+	]);
+	obsidianProcess.kill();
 });
 
 test("Unregister test vault", async () => {

--- a/tests/e2e-setup/setup.ts
+++ b/tests/e2e-setup/setup.ts
@@ -20,10 +20,30 @@ test.beforeEach(async () => {
 	app = await electron.launch({
 		args: [appPath, "open"],
 	});
+
+	// Handle JS dialogs (e.g. beforeunload on app close) explicitly.
+	// Playwright's implicit auto-dismiss races with Obsidian closing its own
+	// dialogs ("No dialog is showing" protocol error), which hangs teardown.
+	const handleDialogs = (page) => {
+		page.on("dialog", (dialog) => dialog.accept().catch(() => {}));
+	};
+	app.on("window", handleDialogs);
+	for (const page of app.windows()) {
+		handleDialogs(page);
+	}
 });
 
 test.afterEach(async () => {
-	await app?.close();
+	if (!app) return;
+	// app.close() can hang if Obsidian blocks shutdown, so bound it and
+	// force-kill as a fallback. The process handle must be grabbed before
+	// close(): a disposed ElectronApplication throws from process().
+	const obsidianProcess = app.process();
+	await Promise.race([
+		app.close(),
+		new Promise((resolve) => setTimeout(resolve, 15_000)),
+	]);
+	obsidianProcess.kill();
 });
 
 test("Set up test vault to make plugin ready to use when Obsidian opens", async () => {

--- a/tests/e2e/sample.spec.ts
+++ b/tests/e2e/sample.spec.ts
@@ -24,10 +24,30 @@ test.beforeEach(async () => {
 			`obsidian://open?path=${encodeURIComponent(vaultPath)}`,
 		],
 	});
+
+	// Handle JS dialogs (e.g. beforeunload on app close) explicitly.
+	// Playwright's implicit auto-dismiss races with Obsidian closing its own
+	// dialogs ("No dialog is showing" protocol error), which hangs teardown.
+	const handleDialogs = (page) => {
+		page.on("dialog", (dialog) => dialog.accept().catch(() => {}));
+	};
+	app.on("window", handleDialogs);
+	for (const page of app.windows()) {
+		handleDialogs(page);
+	}
 });
 
 test.afterEach(async () => {
-	await app?.close();
+	if (!app) return;
+	// app.close() can hang if Obsidian blocks shutdown, so bound it and
+	// force-kill as a fallback. The process handle must be grabbed before
+	// close(): a disposed ElectronApplication throws from process().
+	const obsidianProcess = app.process();
+	await Promise.race([
+		app.close(),
+		new Promise((resolve) => setTimeout(resolve, 15_000)),
+	]);
+	obsidianProcess.kill();
 });
 
 test("最近2番目に開いたファイルが含まれる", async () => {


### PR DESCRIPTION
Ports the fixes validated in obsidian-core-search-assistant-plugin#87:

- Handle JS dialogs explicitly: Playwright's implicit auto-dismiss races
  with Obsidian closing its own dialogs ('No dialog is showing'), which
  hangs teardown for the full worker timeout.
- Bound app.close() with a 15s race and force-kill the process as a
  fallback (handle grabbed before close(): a disposed ElectronApplication
  throws from process()).
