### PR TITLE
ci: declare least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   tagpr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       tagpr-tag: ${{ steps.tagpr.outputs.tag }}
     steps:
@@ -20,6 +23,8 @@ jobs:
     needs: [tagpr]
     if: needs.tagpr.outputs.tagpr-tag != ''
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2


### PR DESCRIPTION
## Why
Workflows had no `permissions:` block, so `GITHUB_TOKEN` used the repository default (possibly read/write). If a third-party action were compromised, it could push to `main` or alter GitHub Releases — the distribution channel for this plugin.

## What
- `ci.yml` (if present): workflow-level `contents: read`
- `tagpr.yml`: `tagpr` job gets `contents: write` + `pull-requests: write` (required by Songmu/tagpr); `release` job gets `contents: write` (release upload). Nothing else.

Part of a series applied to all of my Obsidian plugin repos.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8