### PR TITLE
ci: build release with pnpm --frozen-lockfile

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -28,9 +28,9 @@ jobs:
           install: true
           cache: true # [default: true] cache mise using GitHub's cache
       - name: Install dependencies
-        run: npm install
+        run: pnpm install --frozen-lockfile
       - name: Build
-        run: npm run build
+        run: pnpm build
       - name: Upload build artifact to release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Why
The `release` job in `tagpr.yml` ran `npm install` / `npm run build`, which ignores `pnpm-lock.yaml` and resolves dependencies from scratch on every release. The `main.js` distributed to users was built from an unpinned dependency set — a worse supply-chain exposure than any CI run.

## What
- `npm install` → `pnpm install --frozen-lockfile`
- `npm run build` → `pnpm build`

pnpm is already installed by `jdx/mise-action` from `mise.toml`. Verified locally that `pnpm install --frozen-lockfile` succeeds against the current lockfile.

Part of a series applied to all of my Obsidian plugin repos.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8