### PR TITLE
e2e: survive a confirmation modal at startup; disable auto-update in CI

### DIFF
--- a/tests/e2e-setup/setup.ts
+++ b/tests/e2e-setup/setup.ts
@@ -72,4 +72,12 @@ test("Set up test vault to make plugin ready to use when Obsidian opens", async 
 
 	// Close a modal for community plugins
 	await window.keyboard.press("Escape");
+
+	// Turn off Obsidian's auto-updater for this (throw-away) install: CI must
+	// test the version it downloaded, not whatever the updater fetches, and the
+	// update flow must not pop UI over the tests. Persisted in the app config.
+	const updatesDisabled = await window.evaluate(() =>
+		require("electron").ipcRenderer.sendSync("disable-update", true),
+	);
+	expect(updatesDisabled).toBe(true);
 });

--- a/tests/e2e/sample.spec.ts
+++ b/tests/e2e/sample.spec.ts
@@ -1,6 +1,8 @@
 import test, {
 	expect,
 	type ElectronApplication,
+	type Locator,
+	type Page,
 	_electron as electron,
 } from "@playwright/test";
 import fs from "node:fs/promises";
@@ -10,6 +12,44 @@ const appPath = path.resolve("./.obsidian-unpacked/main.js");
 const vaultPath = path.resolve("./tests/test-vault");
 
 let app: ElectronApplication;
+
+/**
+ * Click `target`, first dismissing any confirmation modal Obsidian may have
+ * opened on startup. In CI a `.modal-container.mod-confirmation` sometimes
+ * appears right after launch and swallows the first click (flaky timeout).
+ * The trust prompt must be accepted, anything else is closed with Escape.
+ * The modal text is logged so the cause is visible in the CI log.
+ */
+async function clickPastStartupModals(window: Page, target: Locator) {
+	const attempts = 10;
+	for (let i = 0; i < attempts; i++) {
+		const modal = window.locator(".modal-container");
+		if ((await modal.count()) > 0) {
+			const text = (await modal.first().innerText())
+				.replace(/\s+/g, " ")
+				.slice(0, 200);
+			console.log(`[e2e] modal open at startup, dismissing: ${text}`);
+			const trust = modal.getByRole("button", {
+				name: "Trust author and enable plugins",
+			});
+			if ((await trust.count()) > 0) {
+				await trust.click();
+			} else {
+				await window.keyboard.press("Escape");
+			}
+			await modal
+				.first()
+				.waitFor({ state: "detached", timeout: 5_000 })
+				.catch(() => {});
+		}
+		try {
+			await target.click({ timeout: 3_000 });
+			return;
+		} catch (e) {
+			if (i === attempts - 1) throw e;
+		}
+	}
+}
 
 test.beforeEach(async () => {
 	await fs.rm(path.join(vaultPath, ".obsidian", "workspace.json"), {
@@ -55,7 +95,10 @@ test("最近2番目に開いたファイルが含まれる", async () => {
 	// ファイルhogeを開く
 	{
 		// Quick switcherを開く
-		await window.getByLabel("Open quick switcher", { exact: true }).click();
+		await clickPastStartupModals(
+			window,
+			window.getByLabel("Open quick switcher", { exact: true }),
+		);
 		const quickSwitcher = window.locator(":focus");
 		// Quick switcherに入力
 		await quickSwitcher.fill("hoge");


### PR DESCRIPTION
## Symptom
Since 2026-08-22 the first click of the e2e test intermittently times out in CI. Playwright's call log shows the target element is found but `<div class="modal-bg"> from <div class="modal-container mod-confirmation mod-dim">` intercepts pointer events — a confirmation modal is open right after launch. Same symptom in core-search-assistant and card-view-switcher.

It started right after Obsidian **1.13.8** was published (2026-08-21) while CI still runs **1.13.7** (1.13.8 ships no dmg), so the auto-updater is the prime suspect. It does not reproduce locally, so the exact modal is not confirmed yet.

## Fix
- `clickPastStartupModals(window, target)`: before the first interaction, if a modal is open, accept the *Trust author* prompt when that is what it is, otherwise press Escape; then click. The modal's text is `console.log`ged so the real cause shows up in the CI log next time it happens.
- `setup.ts`: persist `disable-update` through Obsidian's own IPC (`ipcRenderer.sendSync("disable-update", true)`, the same call the *Automatic updates* toggle uses). A throw-away CI install must test the version it downloaded, not whatever the updater fetches — and the update flow must not pop UI over the tests.

## Verification
CI e2e run several times on this branch (see checks / dispatched runs).

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8