### PR TITLE
ci: add a 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Dependabot resolves versions itself, so .npmrc's minimum-release-age does
+    # not apply to its PRs. Mirror it: wait 7 days after a release before proposing it.
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       npm-minor-patch:
         update-types:


### PR DESCRIPTION
Dependabot resolves versions on GitHub's side, so `.npmrc`'s `minimum-release-age` (#52) does not apply to its PRs. `cooldown: 7 days` mirrors it so a freshly published version is never proposed before it has had a week to be yanked.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8