### PR TITLE
ci: let Dependabot bump electron majors; warn on drift from Obsidian's Electron

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,9 +31,6 @@ updates:
       # Must match the Node major we run (mise.toml), not the newest available.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
-      # Must match the Electron bundled in current Obsidian, which the e2e tests emulate.
-      - dependency-name: electron
-        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         update-types:

--- a/scripts/setup-obsidian.sh
+++ b/scripts/setup-obsidian.sh
@@ -79,6 +79,27 @@ else
 fi
 
 # ------------------------------------------------------------------------------
+# 2b. Electron drift check
+# ------------------------------------------------------------------------------
+# The e2e tests run Obsidian's sources on the npm `electron` binary, not on the
+# one inside Obsidian.app, so the devDependency should track the major that
+# Obsidian bundles. Dependabot bumps majors on its own (after cooldown); this
+# only warns when the two have drifted apart so a human can decide.
+obsidian_electron="$(plutil -extract CFBundleVersion raw -o - \
+  "$obsidian_app/Contents/Frameworks/Electron Framework.framework/Resources/Info.plist")"
+our_electron="$(node -p "require('electron/package.json').version")"
+if [[ "${obsidian_electron%%.*}" != "${our_electron%%.*}" ]]; then
+  msg="Electron major mismatch: Obsidian $(defaults read "$obsidian_app/Contents/Info.plist" CFBundleShortVersionString) bundles Electron $obsidian_electron but devDependency electron is $our_electron. Consider bumping electron to ${obsidian_electron%%.*}.x in package.json."
+  if [[ "$MODE" == "ci" ]]; then
+    echo "::warning title=Electron drift::$msg"
+  else
+    echo "⚠️  $msg" >&2
+  fi
+else
+  echo "✅ Electron $our_electron matches Obsidian's bundled major ($obsidian_electron)"
+fi
+
+# ------------------------------------------------------------------------------
 # 3. Extract app.asar and build test folder
 # ------------------------------------------------------------------------------
 echo "🔓 Unpacking $obsidian_app → $unpacked_path"


### PR DESCRIPTION
Goal: keep `electron` (the runtime our e2e tests actually launch) on the **same major** Obsidian bundles — maintained by Dependabot, with drift surfaced by CI rather than remembered by a human.

- **Dependabot**: drop the `electron` major `ignore`. Majors now arrive via the existing `npm-major` group after the 60-day cooldown. Obsidian tracks recent Electron majors, so merging those keeps us aligned without manual tracking. (`typescript` / `@types/node` ignores stay — different reasons.)
- **`scripts/setup-obsidian.sh`**: after obtaining `Obsidian.app`, read the bundled Electron version from `Electron Framework.framework/Resources/Info.plist` (`CFBundleVersion`) and compare its major with `node_modules/electron`. On mismatch emit a `::warning` annotation in CI (plain stderr locally). Warning, not failure: drift is a signal for a human, not a broken build.

Until the electron 43 bump lands, CI on this PR is expected to show the warning (Obsidian 1.13.7 bundles 43.3.0, main is on 39.8.10) — which doubles as the check's smoke test.

https://claude.ai/code/session_01HkPBr8tF6q2MeCG3VwksLQ