### PR TITLE
chore: schedule Dependabot on Saturday 03:00 JST

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: saturday
+      time: "03:00"
+      timezone: Asia/Tokyo
     # Security updates bypass cooldown and arrive as soon as an advisory is published.
     # Version updates wait for a release to age: patches barely (they rarely break, and
     # batching them only grows the diff), minors until they have matured.
@@ -16,6 +19,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: saturday
+      time: "03:00"
+      timezone: Asia/Tokyo
     # Security updates bypass cooldown and arrive as soon as an advisory is published.
     # Version updates wait for a release to age: patches barely (they rarely break, and
     # batching them only grows the diff), minors until they have matured.


### PR DESCRIPTION
Run Dependabot version updates once a week on Saturday at 03:00 JST instead of a randomly assigned time.

- `day: saturday`, `time: "03:00"`, `timezone: Asia/Tokyo` on every `schedule` block
- `time` is quoted on purpose: the Ruby YAML parser reads a bare `03:00` as the integer 10800
- Security updates are unaffected; they are raised as soon as an advisory is published

https://claude.ai/code/session_01ThX2Z7h3iUUMFxBPWXpEEe
