### PR TITLE
Tighten Dependabot and CI supply-chain policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,8 @@ updates:
       day: saturday
       time: "03:00"
       timezone: Asia/Tokyo
-    # Security updates bypass cooldown and arrive as soon as an advisory is published.
     # github-actions does not support per-semver cooldown (semver-*-days are ignored and
-    # Dependabot silently falls back to its 3-day default), so use a flat one-week cooldown.
+    # Dependabot silently falls back to its 3-day default), so use a flat cooldown.
     cooldown:
       default-days: 7
 
@@ -20,13 +19,22 @@ updates:
       day: saturday
       time: "03:00"
       timezone: Asia/Tokyo
-    # Security updates bypass cooldown and arrive as soon as an advisory is published.
-    # Version updates wait for a release to age: patches barely (they rarely break, and
-    # batching them only grows the diff), minors until they have matured.
+    # Cooldown applies to version updates only. Security updates skip it, but they still
+    # have to pass `minimum-release-age` in .npmrc, which pnpm enforces when Dependabot
+    # regenerates the lockfile: a fix version younger than that gate fails to resolve and
+    # the security PR errors. That is deliberate. A fix version gets no special trust; wait
+    # for it to age unless the advisory is severe and the vulnerable path is actually reachable
+    # from this plugin. In that case bump by hand with `--config.minimum-release-age=0` and say
+    # so in the PR body.
+    #
+    # Days are chosen by the bump type from the *installed* version to the candidate, so from
+    # 1.2.0 both 1.3.0 and 1.3.1 count as minor. A longer minor cooldown therefore never
+    # picks the patched 1.3.1 over 1.3.0 (1.3.1 is always younger); it only delays 1.3.0.
+    # So keep patch and minor at the same length as the .npmrc age gate (7 days), and delay
+    # majors only to leave time for peer dependencies to catch up and to plan the migration.
     cooldown:
-      semver-patch-days: 7
-      semver-minor-days: 30
-      semver-major-days: 60
+      default-days: 7
+      semver-major-days: 30
     # Majors we bump by hand, on purpose:
     ignore:
       # 7.x is the Go-based rewrite (tsgo); stay on the 5.x line until tooling catches up.
@@ -35,11 +43,18 @@ updates:
       # Must match the Node major we run (mise.toml), not the newest available.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+      # Must match the Electron bundled in current Obsidian, which the e2e tests emulate.
+      - dependency-name: electron
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         update-types:
           - minor
           - patch
+        # Bundled into main.js and shipped to users' vaults: review individually.
+        exclude-patterns:
+          - svelte
+          - "svelte-*"
       npm-major:
         update-types:
           - major

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
           install: true
           cache: true
       - run: pnpm install --frozen-lockfile
+      # mise.toml と package.json (packageManager / engines / @types/node) の pnpm・Node version がずれていないか
+      - run: node scripts/check-toolchain.mjs
+      # 全 action が commit SHA に pin されているか (tag 参照を新しく足すと落ちる)
+      - run: node scripts/check-actions-pinned.mjs
+      # dev 依存を含む全体は大きな依存木 (playwright, electron 等) のノイズを避けて high 以上
+      - run: pnpm audit --audit-level=high
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm build

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "main.js",
 	"packageManager": "pnpm@10.33.2",
 	"engines": {
-		"node": ">=22"
+		"node": ">=24.0.0"
 	},
 	"type": "module",
 	"scripts": {
@@ -21,7 +21,8 @@
 		"e2e:setup": "playwright test tests/e2e-setup/setup.ts --project e2e-setup",
 		"e2e:cleanup": "playwright test tests/e2e-setup/cleanup.ts --project e2e-setup",
 		"e2e:test": "playwright test --project e2e",
-		"e2e": "pnpm build && pnpm e2e:test"
+		"e2e": "pnpm build && pnpm e2e:test",
+		"check": "node scripts/check-toolchain.mjs && node scripts/check-actions-pinned.mjs && pnpm lint && pnpm typecheck && pnpm build"
 	},
 	"keywords": [],
 	"author": "",

--- a/scripts/check-actions-pinned.mjs
+++ b/scripts/check-actions-pinned.mjs
@@ -1,0 +1,31 @@
+// .github/workflows 内の `uses:` が全て commit SHA (40桁 hex) に pin されているか検査する。
+// Dependabot は既存の pin を更新するだけで、新しく足された tag 参照 (例: actions/checkout@v7) は指摘しない。
+// tag は後から別の commit に付け替えられるので、review していない code が CI で動くのを防ぐ。
+// ローカル action (./path) と docker:// は対象外。pin の更新は `mise run pin-actions:update`。
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const dir = new URL("../.github/workflows/", import.meta.url);
+const files = readdirSync(dir).filter((f) => /\.ya?ml$/.test(f));
+const errors = [];
+
+for (const file of files) {
+  const lines = readFileSync(join(dir.pathname, file), "utf8").split("\n");
+  lines.forEach((line, i) => {
+    const m = line.match(/^\s*-?\s*uses:\s*["']?([^"'\s#]+)/);
+    if (!m) return;
+    const ref = m[1];
+    if (ref.startsWith("./") || ref.startsWith("docker://")) return;
+    if (!/^[\w.-]+\/[\w.-]+(\/[^@]+)?@[0-9a-f]{40}$/.test(ref)) {
+      errors.push(`${file}:${i + 1}: ${ref}`);
+    }
+  });
+}
+
+if (errors.length > 0) {
+  console.error("actions-pinned: commit SHA に pin されていない action があります:");
+  for (const e of errors) console.error(`  ${e}`);
+  console.error("  `mise run pin-actions` で pin できます。");
+  process.exit(1);
+}
+console.log(`actions-pinned: ok (${files.length} workflow)`);

--- a/scripts/check-toolchain.mjs
+++ b/scripts/check-toolchain.mjs
@@ -1,0 +1,44 @@
+// mise.toml と package.json の toolchain version が一致するか検査する。
+// Dependabot は mise.toml を扱えないので、pnpm / Node を上げるときは両方を手で更新する必要がある。
+// ずれると CI (mise) とローカル (packageManager / engines) で違う version が動くので、ここで止める。
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const mise = readFileSync(new URL("../mise.toml", import.meta.url), "utf8");
+
+function miseTool(name) {
+  const tools = mise.match(/^\[tools\]\n([\s\S]*?)(?=^\[|(?![\s\S]))/m)?.[1] ?? "";
+  return tools.match(new RegExp(`^${name}\\s*=\\s*"([^"]+)"`, "m"))?.[1];
+}
+
+const errors = [];
+
+const pnpmFromPkg = pkg.packageManager?.match(/^pnpm@(\d+\.\d+\.\d+)$/)?.[1];
+const pnpmFromMise = miseTool("pnpm");
+if (!pnpmFromPkg)
+  errors.push(`package.json の packageManager が "pnpm@x.y.z" 形式ではない: ${pkg.packageManager}`);
+if (!pnpmFromMise) errors.push("mise.toml の [tools] に pnpm がない");
+if (pnpmFromPkg && pnpmFromMise && pnpmFromPkg !== pnpmFromMise) {
+  errors.push(`pnpm version がずれている: package.json=${pnpmFromPkg} mise.toml=${pnpmFromMise}`);
+}
+
+// engines.node は ">=24.0.0" / ">=24" / "24.x" のどれでも major だけ見る
+const nodeMajorFromPkg = pkg.engines?.node?.match(/(\d+)/)?.[1];
+const nodeFromMise = miseTool("node");
+if (!nodeMajorFromPkg)
+  errors.push(`package.json の engines.node から major を読めない: ${pkg.engines?.node}`);
+if (!nodeFromMise) errors.push("mise.toml の [tools] に node がない");
+if (nodeMajorFromPkg && nodeFromMise && nodeFromMise.split(".")[0] !== nodeMajorFromPkg) {
+  errors.push(`Node major がずれている: package.json engines=${nodeMajorFromPkg} mise.toml=${nodeFromMise}`);
+}
+
+const typesNodeMajor = pkg.devDependencies?.["@types/node"]?.match(/(\d+)/)?.[1];
+if (typesNodeMajor && nodeMajorFromPkg && typesNodeMajor !== nodeMajorFromPkg) {
+  errors.push(`@types/node の major がずれている: @types/node=${typesNodeMajor} engines=${nodeMajorFromPkg}`);
+}
+
+if (errors.length > 0) {
+  for (const e of errors) console.error(`toolchain: ${e}`);
+  process.exit(1);
+}
+console.log(`toolchain: ok (pnpm ${pnpmFromPkg}, node ${nodeFromMise})`);


### PR DESCRIPTION
harden-deps skill の基準 (Dependabot + CI 層) を追随させる。設定と CI の検査だけで、plugin の code は変えない。

**a. npm の cooldown を「7 日、major のみ 30 日」にした (原則 i)**
旧: patch 7 / minor 30 / major 60。Dependabot は cooldown 日数を「入っている version から候補への bump 種別」で決めるので、minor を長くしても .0 が遅れて来るだけで枯れた patch は選ばれない。patch と minor を `.npmrc` の `minimum-release-age` (7 日) に揃え、major だけ移行準備のために 30 日遅らせる。

**b. security update と age gate の関係をコメントに明文化した (原則 k)**
「advisory 公開と同時に届く」は実態と違う。公開 7 日未満の修正版を指す security PR は pnpm の age gate で失敗するのが意図した挙動で、待てないときだけ手で上げて PR 本文に書く。

**c. electron の major を ignore に追加した**
Obsidian 同梱の Electron に合わせる必要があり、e2e がそれを模している。binary-file-manager 等と同じ理由。

**d. bundle される svelte を group から外した (原則 j)**
全部 devDependencies だが esbuild が svelte を main.js に bundle し、利用者の vault で動く。minor/patch の group に混ぜず個別 PR にして、差分を読んでから merge する。

**e. CI に検査を 3 つ足した (原則 g, l, n)**
`scripts/check-toolchain.mjs` (mise.toml と package.json の pnpm / Node 一致)、`scripts/check-actions-pinned.mjs` (全 `uses:` が commit SHA)、`pnpm audit --audit-level=high`。script は harden-deps skill の asset と同一内容。

**f. `engines.node` を `>=24.0.0` にした**
mise.toml の node は 24、`@types/node` も 24 系なのに `>=22` のままで、toolchain check が不一致として落ちるため。

**g. `pnpm check` を追加した**
CI と同じ一式 (toolchain、pin、lint、typecheck、build) を手元で回すため。e2e は含めない。

## 確認
- worktree で `pnpm install --frozen-lockfile`、両 check script、`pnpm audit --audit-level=high`、`pnpm lint`、`pnpm typecheck`、`pnpm build` が通る
