### PR TITLE
Align check-config-schema.mjs imports with Biome's order

### DIFF
--- a/scripts/check-config-schema.mjs
+++ b/scripts/check-config-schema.mjs
@@ -6,9 +6,9 @@
 //
 //   node scripts/check-config-schema.mjs          # repo root (script の 1 つ上) を検査
 //   node scripts/check-config-schema.mjs <dir>    # 指定 dir を検査 (scan-repos.sh 用)
-import { readFileSync, readdirSync } from "node:fs";
-import { pathToFileURL } from "node:url";
+import { readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const root = process.argv[2]
   ? pathToFileURL(`${resolve(process.argv[2])}/`)


### PR DESCRIPTION
**a. import の並び順だけを変更**
harden-deps skill 側の asset を biome の organizeImports が出す順 (`node:fs` → `node:path` → `node:url`、named は辞書順) に揃えたので、この repo の copy をそれに追随させる。

**b. なぜ**
各 repo は自分の biome 設定で copy を整形するため byte 一致は元々しないが、skill の scan は空白と末尾カンマを落として比較するので整形差は許容される。import の並び順だけは吸収できず `drift=check-config-schema.mjs` として出ていた。

**c. 挙動は変わらない**
import の順序のみ。`node scripts/check-config-schema.mjs` は変更前後どちらも exit 0。