### PR TITLE
Pin dependency ranges to the resolved versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,15 +30,15 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.5.8",
 		"@electron/asar": "4.2.1",
-		"@playwright/test": "^1.59.1",
-		"@tsconfig/svelte": "^5.0.8",
+		"@playwright/test": "1.59.1",
+		"@tsconfig/svelte": "5.0.8",
 		"@types/node": "24.13.3",
-		"electron": "^43.3.0",
-		"esbuild": "^0.28.2",
-		"esbuild-svelte": "^0.9.5",
-		"obsidian": "^1.13.1",
-		"sass": "^1.102.0",
-		"svelte": "^5.56.8",
+		"electron": "43.3.0",
+		"esbuild": "0.28.2",
+		"esbuild-svelte": "0.9.5",
+		"obsidian": "1.13.1",
+		"sass": "1.102.0",
+		"svelte": "5.56.8",
 		"typescript": "5.9.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,31 +15,31 @@ importers:
         specifier: 4.2.1
         version: 4.2.1
       '@playwright/test':
-        specifier: ^1.59.1
+        specifier: 1.59.1
         version: 1.59.1
       '@tsconfig/svelte':
-        specifier: ^5.0.8
+        specifier: 5.0.8
         version: 5.0.8
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
       electron:
-        specifier: ^43.3.0
+        specifier: 43.3.0
         version: 43.3.0
       esbuild:
-        specifier: ^0.28.2
+        specifier: 0.28.2
         version: 0.28.2
       esbuild-svelte:
-        specifier: ^0.9.5
+        specifier: 0.9.5
         version: 0.9.5(esbuild@0.28.2)(svelte@5.56.8)
       obsidian:
-        specifier: ^1.13.1
+        specifier: 1.13.1
         version: 1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
       sass:
-        specifier: ^1.102.0
+        specifier: 1.102.0
         version: 1.102.0
       svelte:
-        specifier: ^5.56.8
+        specifier: 5.56.8
         version: 5.56.8
       typescript:
         specifier: 5.9.3


### PR DESCRIPTION
**a. 何を変えたか**
`package.json` に残っていた `^` の範囲指定 8 件を、`pnpm-lock.yaml` が既に解決している version にそのまま書き換えた。upgrade は一切していない。

**b. 依存ツリーは変わっていない**
lockfile の差分は specifier 行のみ (16 行)。version / resolution / integrity の変更は 0 行。

**c. なぜ exact pin か (原則 a)**
範囲指定のままだと、lockfile を作り直す操作のたびに解決が動きうる。悪性版が publish された直後にその窓が開く。`.npmrc` の `save-exact` は **これから追加する依存にしか効かない** ので、既存の範囲は手で潰す必要がある。

**d. 検証**
`pnpm install --frozen-lockfile`、`pnpm lint`、`pnpm typecheck`、`pnpm build` が通る。